### PR TITLE
Use pip cache from setup-python action

### DIFF
--- a/.github/workflows/auto_update_stat_images.yml
+++ b/.github/workflows/auto_update_stat_images.yml
@@ -30,15 +30,8 @@ jobs:
       with:
         python-version: '3.10'
         architecture: 'x64'
-
-    # Cache dependencies. From:
-    # https://github.com/actions/cache/blob/master/examples.md#python---pip
-    - uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+        cache: pip
+        cache-dependency-path: '**/requirements.txt'
 
     # Switch to actions_branch if not exist, or create new actions_branch
     - name: Switch to actions_branch

--- a/.github/workflows/non_auto_generate_stat_images.yml
+++ b/.github/workflows/non_auto_generate_stat_images.yml
@@ -30,15 +30,8 @@ jobs:
       with:
         python-version: '3.10'
         architecture: 'x64'
-
-    # Cache dependencies. From:
-    # https://github.com/actions/cache/blob/master/examples.md#python---pip
-    - uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+        cache: pip
+        cache-dependency-path: '**/requirements.txt'
 
     # Creates a new branch for generating images or overwrites from older edits
     - name: Create new branch


### PR DESCRIPTION
A step in the workflows can be replaced with the cache already built into the setup-python action, see https://github.com/actions/setup-python#caching-packages-dependencies