### PR TITLE
Make all fields visible of SVG content area

### DIFF
--- a/src/templates/overview.svg
+++ b/src/templates/overview.svg
@@ -1,4 +1,4 @@
-<svg width="345" height="260" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 345 260">
+<svg width="400" height="390" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 390">
   <style>
     svg {
       font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
@@ -105,7 +105,7 @@
   <g>
     <rect x="5" y="5" id="background"/>
     <g>
-      <foreignObject x="21" y="21" width="304.6" height="208">
+      <foreignObject x="21" y="21" width="400" height="208">
         <div xmlns="http://www.w3.org/1999/xhtml">
 
           <table>


### PR DESCRIPTION
Increased the length and width of SVG content area to make all fields and values visible because not all fields and values are when default size (length and width) are used.